### PR TITLE
feat: define base component info

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,3 +1,6 @@
+# Metadata for the backstage catalog accessible at this link:  
+# https://backstage.cdssandbox.xyz/  
+---
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: notification-github-action
+  title: GC Notification GitHub Action
+  description: An action to send a message from a GitHub CI using GC Notify (or any other Notify fork).
+  annotations:
+    github.com/project-slug: gc-notification-github-action
+spec:
+  type: service
+  owner: group:cds-snc/notify-dev
+  system: gc-notification
+  lifecycle: production


### PR DESCRIPTION
# Summary | Résumé

Setting up base catalog info for the GH Action as a component of type "service" and currently in production.